### PR TITLE
lang: UnsafeAccount type alias

### DIFF
--- a/examples/misc/programs/misc/src/lib.rs
+++ b/examples/misc/programs/misc/src/lib.rs
@@ -59,8 +59,8 @@ pub struct Initialize<'info> {
 #[derive(Accounts)]
 pub struct TestOwner<'info> {
     #[account(owner = misc)]
-    data: AccountInfo<'info>,
-    misc: AccountInfo<'info>,
+    data: UnsafeAccount<'info>,
+    misc: UnsafeAccount<'info>,
 }
 
 #[derive(Accounts)]

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -216,6 +216,7 @@ pub mod prelude {
     };
 
     pub use borsh;
+    pub use solana_program::account_info::AccountInfo as UnsafeAccount;
     pub use solana_program::account_info::{next_account_info, AccountInfo};
     pub use solana_program::entrypoint::ProgramResult;
     pub use solana_program::instruction::AccountMeta;

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -69,6 +69,11 @@ pub use anchor_derive_accounts::Accounts;
 /// Borsh is the default serialization format for instructions and accounts.
 pub use borsh::{BorshDeserialize as AnchorDeserialize, BorshSerialize as AnchorSerialize};
 pub use solana_program;
+/// Alias for [`AccountInfo`](../solana_program/instruction/struct.AccountInfo.html),
+/// as a reminder that the account is not validated and untrusted. When using
+/// an `UnsafeAccount`, one must manuallly validate its contents are consistent
+/// with what the program expects.
+pub use solana_program::account_info::AccountInfo as UnsafeAccount;
 
 /// A data structure of validated accounts that can be deserialized from the
 /// input to a Solana program. Implementations of this trait should perform any

--- a/lang/syn/src/lib.rs
+++ b/lang/syn/src/lib.rs
@@ -125,7 +125,7 @@ impl AccountsStruct {
                 AccountField::AccountsStruct(comp_f) => {
                     let accs_strct = global_accs
                         .get(&comp_f.symbol)
-                        .expect("Could not reslve Accounts symbol");
+                        .expect("Could not resolve Accounts symbol");
                     let accounts = accs_strct.idl_accounts(global_accs);
                     IdlAccountItem::IdlAccounts(IdlAccounts {
                         name: comp_f.ident.to_string().to_mixed_case(),

--- a/lang/syn/src/parser/accounts.rs
+++ b/lang/syn/src/parser/accounts.rs
@@ -69,7 +69,7 @@ fn parse_field(f: &syn::Field, anchor: Option<&syn::Attribute>) -> AccountField 
 fn is_field_primitive(f: &syn::Field) -> bool {
     match ident_string(f).as_str() {
         "ProgramState" | "ProgramAccount" | "CpiAccount" | "Sysvar" | "AccountInfo"
-        | "CpiState" => true,
+        | "CpiState" | "UnsafeAccount" => true,
         _ => false,
     }
 }
@@ -86,6 +86,7 @@ fn parse_ty(f: &syn::Field) -> Ty {
         "CpiAccount" => Ty::CpiAccount(parse_cpi_account(&path)),
         "Sysvar" => Ty::Sysvar(parse_sysvar(&path)),
         "AccountInfo" => Ty::AccountInfo,
+        "UnsafeAccount" => Ty::AccountInfo,
         _ => panic!("invalid account type"),
     }
 }


### PR DESCRIPTION
Introduces `UnsafeAccount` as a type alias to `AccountInfo`.