### PR TITLE
example: Add example for light and light switch 1-1 relationship

### DIFF
--- a/examples/light-switch/.gitignore
+++ b/examples/light-switch/.gitignore
@@ -1,9 +1,0 @@
-# ignore Mac OS noise
-.DS_Store
-
-# ignore the build directory for Rust/Anchor
-target
-
-# Ignore backup files creates by cargo fmt.
-**/*.rs.bk
-    

--- a/examples/light-switch/.gitignore
+++ b/examples/light-switch/.gitignore
@@ -1,0 +1,9 @@
+# ignore Mac OS noise
+.DS_Store
+
+# ignore the build directory for Rust/Anchor
+target
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+    

--- a/examples/light-switch/Anchor.toml
+++ b/examples/light-switch/Anchor.toml
@@ -1,0 +1,2 @@
+cluster = "localnet"
+wallet = "~/.config/solana/id.json"

--- a/examples/light-switch/Cargo.toml
+++ b/examples/light-switch/Cargo.toml
@@ -1,0 +1,4 @@
+[workspace]
+members = [
+    "programs/*"
+]

--- a/examples/light-switch/migrations/deploy.js
+++ b/examples/light-switch/migrations/deploy.js
@@ -1,0 +1,13 @@
+
+// Migrations are an early feature. Currently, they're nothing more than this
+// single deploy script that's invoked from the CLI, injecting a provider
+// configured from the workspace's Anchor.toml.
+
+const anchor = require("@project-serum/anchor");
+
+module.exports = async function (provider) {
+  // Configure client to use the provider.
+  anchor.setProvider(provider);
+
+  // Add your deploy script here.
+}

--- a/examples/light-switch/programs/light-switch/Cargo.toml
+++ b/examples/light-switch/programs/light-switch/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "light-switch"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "light_switch"
+
+[features]
+no-entrypoint = []
+no-idl = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang = "0.4.4"
+light = { path = "../light", features = ["cpi"] }

--- a/examples/light-switch/programs/light-switch/Xargo.toml
+++ b/examples/light-switch/programs/light-switch/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/examples/light-switch/programs/light-switch/src/lib.rs
+++ b/examples/light-switch/programs/light-switch/src/lib.rs
@@ -1,0 +1,85 @@
+/*
+Light and Light Switch program with one to one relationship.
+They share the same switch account and only transaction signed by that account is able to turn light on and off.
+
+This is a community example and might not represent the best practices.
+*/
+
+use anchor_lang::prelude::*;
+use light::light::{Light};
+use light::{FlipSwitch};
+
+#[program]
+pub mod light_switch {
+    use super::*;
+
+    #[state]
+    pub struct LightSiwtch {
+        authority: Pubkey,
+        switch: Pubkey
+    }
+
+
+    impl LightSiwtch {
+        pub fn new(ctx: Context<SwitchInit>) -> Result<Self> {
+            Ok(Self {
+                authority: *ctx.accounts.authority.key,
+                switch: *ctx.accounts.switch.key
+            })
+        }
+
+        pub fn flip(&mut self, ctx: Context<StateCpi>, nonce: u8) -> Result<()> {
+
+            // check authority is the signer
+            // check owner being passed in is same owner in state
+            if &self.authority != ctx.accounts.authority.key || &self.switch != ctx.accounts.switch.key{
+                return Err(ErrorCode::Unauthorized.into());
+            }
+
+            // obtain the light program
+            let cpi_program = ctx.accounts.light_program.clone();
+
+            // set the payload, pass in switch
+            let cpi_accounts = FlipSwitch {
+                switch: ctx.accounts.switch.to_account_info()
+            };
+
+            // sign with master and nonce of PDA (owner signer)
+            let seeds = &[
+                ctx.accounts.switch.to_account_info().key.as_ref(),
+                &[nonce],
+            ];
+            let signer = &[&seeds[..]];
+            let ctx = ctx.accounts.cpi_state.context(cpi_program, cpi_accounts);
+
+            // call cpi function with signer
+            light::cpi::state::flip(ctx.with_signer(signer));
+            Ok(())
+        }
+    }
+
+}
+
+#[derive(Accounts)]
+pub struct SwitchInit<'info> {
+    #[account(signer)]
+    authority: AccountInfo<'info>,
+    switch: AccountInfo<'info>
+}
+
+#[derive(Accounts)]
+pub struct StateCpi<'info> {
+    #[account(signer)]
+    authority: AccountInfo<'info>,
+    switch: AccountInfo<'info>,
+    #[account(mut, state = light_program)]
+    cpi_state: CpiState<'info, Light>,
+    #[account(executable)]
+    light_program: AccountInfo<'info>,
+}
+
+#[error]
+pub enum ErrorCode {
+    #[msg("You are not authorized to perform this action.")]
+    Unauthorized,
+}

--- a/examples/light-switch/programs/light-switch/src/lib.rs
+++ b/examples/light-switch/programs/light-switch/src/lib.rs
@@ -1,9 +1,7 @@
-/*
-Light and Light Switch program with one to one relationship.
-They share the same switch account and only transaction signed by that account is able to turn light on and off.
+// Light and Light Switch program with one to one relationship.
+// They share the same switch account and only transaction signed by that account is able to turn light on and off.
 
-This is a community example and might not represent the best practices.
-*/
+// This is a community example and might not represent the best practices.
 
 use anchor_lang::prelude::*;
 use light::light::{Light};
@@ -14,13 +12,13 @@ pub mod light_switch {
     use super::*;
 
     #[state]
-    pub struct LightSiwtch {
+    pub struct LightSwitch {
         authority: Pubkey,
         switch: Pubkey
     }
 
 
-    impl LightSiwtch {
+    impl LightSwitch {
         pub fn new(ctx: Context<SwitchInit>) -> Result<Self> {
             Ok(Self {
                 authority: *ctx.accounts.authority.key,
@@ -30,21 +28,21 @@ pub mod light_switch {
 
         pub fn flip(&mut self, ctx: Context<StateCpi>, nonce: u8) -> Result<()> {
 
-            // check authority is the signer
-            // check owner being passed in is same owner in state
+            // Check authority is the signer.
+            // Check owner being passed in is same owner in state.
             if &self.authority != ctx.accounts.authority.key || &self.switch != ctx.accounts.switch.key{
                 return Err(ErrorCode::Unauthorized.into());
             }
 
-            // obtain the light program
+            // Obtain the light program.
             let cpi_program = ctx.accounts.light_program.clone();
 
-            // set the payload, pass in switch
+            // Set the payload, pass in switch.
             let cpi_accounts = FlipSwitch {
                 switch: ctx.accounts.switch.to_account_info()
             };
 
-            // sign with master and nonce of PDA (owner signer)
+            // Sign with master and nonce of PDA (owner signer).
             let seeds = &[
                 ctx.accounts.switch.to_account_info().key.as_ref(),
                 &[nonce],
@@ -52,7 +50,7 @@ pub mod light_switch {
             let signer = &[&seeds[..]];
             let ctx = ctx.accounts.cpi_state.context(cpi_program, cpi_accounts);
 
-            // call cpi function with signer
+            // Call cpi function with signer.
             light::cpi::state::flip(ctx.with_signer(signer));
             Ok(())
         }

--- a/examples/light-switch/programs/light/Cargo.toml
+++ b/examples/light-switch/programs/light/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "light"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "light"
+
+[features]
+no-entrypoint = []
+no-idl = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang = "0.4.4"

--- a/examples/light-switch/programs/light/Xargo.toml
+++ b/examples/light-switch/programs/light/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/examples/light-switch/programs/light/src/lib.rs
+++ b/examples/light-switch/programs/light/src/lib.rs
@@ -1,9 +1,8 @@
-/*
-Light and Light Switch program with one to one relationship.
-They share the same switch account and only transaction signed by that account is able to turn light on and off.
+// Light and Light Switch program with one to one relationship.
+// They share the same switch account and only transaction signed by that account is able to turn light on and off.
 
-This is a community example and might not represent the best practices.
-*/
+// This is a community example and might not represent the best practices.
+
 use anchor_lang::prelude::*;
 
 #[program]
@@ -25,7 +24,7 @@ pub mod light {
         }
 
         pub fn flip(&mut self, ctx: Context<FlipSwitch>) -> Result<()> {
-            // check the switch passed in is also the switch stored
+            // Check the switch passed in is also the switch stored.
             if &self.switch != ctx.accounts.switch.key {
                 return Err(ErrorCode::Unauthorized.into());
             }
@@ -42,7 +41,8 @@ pub struct Init<'info>{
 
 #[derive(Accounts)]
 pub struct FlipSwitch<'info> {
-    #[account(signer)] // verifies master is the signer
+    // Verifies master is the signer.
+    #[account(signer)]
     pub switch: AccountInfo<'info>,
 }
 

--- a/examples/light-switch/programs/light/src/lib.rs
+++ b/examples/light-switch/programs/light/src/lib.rs
@@ -1,0 +1,53 @@
+/*
+Light and Light Switch program with one to one relationship.
+They share the same switch account and only transaction signed by that account is able to turn light on and off.
+
+This is a community example and might not represent the best practices.
+*/
+use anchor_lang::prelude::*;
+
+#[program]
+pub mod light {
+    use super::*;
+
+    #[state]
+    pub struct Light {
+        is_light_on: bool,
+        switch: Pubkey
+    }
+
+    impl Light {
+        pub fn new(ctx: Context<Init>) -> Result<Self> {
+            Ok(Self {
+                is_light_on: false,
+                switch: *ctx.accounts.switch.key
+            })
+        }
+
+        pub fn flip(&mut self, ctx: Context<FlipSwitch>) -> Result<()> {
+            // check the switch passed in is also the switch stored
+            if &self.switch != ctx.accounts.switch.key {
+                return Err(ErrorCode::Unauthorized.into());
+            }
+            self.is_light_on = !self.is_light_on;
+            Ok(())
+        }
+    }
+}
+
+#[derive(Accounts)]
+pub struct Init<'info>{
+    switch:AccountInfo<'info>
+}
+
+#[derive(Accounts)]
+pub struct FlipSwitch<'info> {
+    #[account(signer)] // verifies master is the signer
+    pub switch: AccountInfo<'info>,
+}
+
+#[error]
+pub enum ErrorCode {
+    #[msg("You are not authorized to perform this action.")]
+    Unauthorized,
+}

--- a/examples/light-switch/tests/light-switch.js
+++ b/examples/light-switch/tests/light-switch.js
@@ -1,0 +1,98 @@
+const assert = require("assert");
+const anchor = require('@project-serum/anchor');
+
+describe('initialize light switch', () => {
+
+  const provider = anchor.Provider.local();
+
+  // Configure the client to use the local cluster.
+  anchor.setProvider(provider);
+
+  // initialize programs
+  const light = anchor.workspace.Light;
+  const lightSwitch = anchor.workspace.LightSwitch;
+  let switchSigner = null;
+  let nonce = null
+  const switchAccount = new anchor.web3.Account();
+
+  it('Is initialized!', async () => {
+
+
+    // obtain PDA for switch
+    let [
+      _switchSigner,
+      _nonce,
+    ] = await anchor.web3.PublicKey.findProgramAddress(
+      [switchAccount.publicKey.toBuffer()],
+      lightSwitch.programId
+    );
+    switchSigner = _switchSigner;
+    nonce = _nonce
+
+    // initialize light with switch account
+    await light.state.rpc.new({
+      accounts: {
+        switch: switchAccount.publicKey,
+      }
+    });
+
+    // initialize light with authority and switch account
+    // both light and light switch share the same switch account key.
+    await lightSwitch.state.rpc.new({
+          accounts: {
+            authority: provider.wallet.publicKey,
+            switch: switchAccount.publicKey,
+          },
+    });
+
+    // Fetch the state struct from the network.
+    const state = await light.state();
+    // light is initialized, and not on
+    assert.ok(!state.isLightOn);
+  });
+
+    it("Light switch is able to turn on the light", async () => {
+
+      await lightSwitch.state.rpc.flip(nonce, {
+        accounts: {
+          authority: provider.wallet.publicKey, // only authority can perform the instruction
+          switch: switchAccount.publicKey, // pass in switch account
+          cpiState: await light.state.address(), // current state of light
+          lightProgram: light.programId, // light program ID
+        },
+        signers:[switchAccount] // signed by switch account
+
+      });
+      const state = await light.state();
+      assert.ok(state.isLightOn); // light is on
+    });
+
+    it("Random switch is not able to turn off the light", async () => {
+      const fakeSwitchAccount = new anchor.web3.Account();
+      let [
+          _fakeSigner,
+          _nonce,
+        ] = await anchor.web3.PublicKey.findProgramAddress(
+          [fakeSwitchAccount.publicKey.toBuffer()],
+          lightSwitch.programId
+        );
+
+    try{
+      await lightSwitch.state.rpc.flip(_nonce, {
+        accounts: {
+          authority: provider.wallet.publicKey, // only authority can perform the instruction
+          switch: switchAccount.publicKey, // pass in switch account
+          cpiState: await light.state.address(), // current state of light
+          lightProgram: light.programId, // light program ID
+        },
+        signers:[fakeSwitchAccount] // sign by new fake account
+      });
+    } catch (err) {
+    }
+      const state = await light.state();
+      assert.ok(state.isLightOn); // light is still on
+    });
+
+
+
+});

--- a/examples/light-switch/tests/light-switch.js
+++ b/examples/light-switch/tests/light-switch.js
@@ -1,24 +1,21 @@
 const assert = require("assert");
-const anchor = require('@project-serum/anchor');
+const anchor = require("@project-serum/anchor");
 
-describe('initialize light switch', () => {
-
+describe("initialize light switch", () => {
   const provider = anchor.Provider.local();
 
   // Configure the client to use the local cluster.
   anchor.setProvider(provider);
 
-  // initialize programs
+  // Initialize programs.
   const light = anchor.workspace.Light;
   const lightSwitch = anchor.workspace.LightSwitch;
   let switchSigner = null;
-  let nonce = null
+  let nonce = null;
   const switchAccount = new anchor.web3.Account();
 
-  it('Is initialized!', async () => {
-
-
-    // obtain PDA for switch
+  it("Is initialized!", async () => {
+    // Obtain PDA for switch.
     let [
       _switchSigner,
       _nonce,
@@ -27,72 +24,63 @@ describe('initialize light switch', () => {
       lightSwitch.programId
     );
     switchSigner = _switchSigner;
-    nonce = _nonce
+    nonce = _nonce;
 
-    // initialize light with switch account
+    // Initialize light with switch account.
     await light.state.rpc.new({
       accounts: {
         switch: switchAccount.publicKey,
-      }
+      },
     });
 
-    // initialize light with authority and switch account
-    // both light and light switch share the same switch account key.
+    // Initialize light switch with authority and switch account.
+    // Both light and light switch share the same switch account key.
     await lightSwitch.state.rpc.new({
-          accounts: {
-            authority: provider.wallet.publicKey,
-            switch: switchAccount.publicKey,
-          },
+      accounts: {
+        authority: provider.wallet.publicKey,
+        switch: switchAccount.publicKey,
+      },
     });
 
     // Fetch the state struct from the network.
     const state = await light.state();
-    // light is initialized, and not on
+    // Light is initialized, and not on.
     assert.ok(!state.isLightOn);
   });
 
-    it("Light switch is able to turn on the light", async () => {
-
-      await lightSwitch.state.rpc.flip(nonce, {
-        accounts: {
-          authority: provider.wallet.publicKey, // only authority can perform the instruction
-          switch: switchAccount.publicKey, // pass in switch account
-          cpiState: await light.state.address(), // current state of light
-          lightProgram: light.programId, // light program ID
-        },
-        signers:[switchAccount] // signed by switch account
-
-      });
-      const state = await light.state();
-      assert.ok(state.isLightOn); // light is on
+  it("Light switch is able to turn on the light", async () => {
+    await lightSwitch.state.rpc.flip(nonce, {
+      accounts: {
+        authority: provider.wallet.publicKey, // Only authority can perform the instruction.
+        switch: switchAccount.publicKey, // Pass in switch account.
+        cpiState: await light.state.address(), // Current state of light.
+        lightProgram: light.programId, // Light program ID.
+      },
+      signers: [switchAccount], // Signed by switch account.
     });
+    const state = await light.state();
+    assert.ok(state.isLightOn); // Light is on.
+  });
 
-    it("Random switch is not able to turn off the light", async () => {
-      const fakeSwitchAccount = new anchor.web3.Account();
-      let [
-          _fakeSigner,
-          _nonce,
-        ] = await anchor.web3.PublicKey.findProgramAddress(
-          [fakeSwitchAccount.publicKey.toBuffer()],
-          lightSwitch.programId
-        );
+  it("Random switch is not able to turn off the light", async () => {
+    const fakeSwitchAccount = new anchor.web3.Account();
+    let [_fakeSigner, _nonce] = await anchor.web3.PublicKey.findProgramAddress(
+      [fakeSwitchAccount.publicKey.toBuffer()],
+      lightSwitch.programId
+    );
 
-    try{
+    try {
       await lightSwitch.state.rpc.flip(_nonce, {
         accounts: {
-          authority: provider.wallet.publicKey, // only authority can perform the instruction
-          switch: switchAccount.publicKey, // pass in switch account
-          cpiState: await light.state.address(), // current state of light
-          lightProgram: light.programId, // light program ID
+          authority: provider.wallet.publicKey, // Only authority can perform the instruction.
+          switch: switchAccount.publicKey, // Pass in switch account.
+          cpiState: await light.state.address(), // Current state of light.
+          lightProgram: light.programId, // Light program ID.
         },
-        signers:[fakeSwitchAccount] // sign by new fake account
+        signers: [fakeSwitchAccount], // Sign by new fake account.
       });
-    } catch (err) {
-    }
-      const state = await light.state();
-      assert.ok(state.isLightOn); // light is still on
-    });
-
-
-
+    } catch (err) {}
+    const state = await light.state();
+    assert.ok(state.isLightOn); // Light is still on.
+  });
 });


### PR DESCRIPTION
Added example of light and light switch.

Only one switch can do CPI call to update the light switch's state. 

Felt like it has lots of redundancies and not very well written. Perhaps it's not even the right way to implement. 

Accepting any comments