### PR TITLE
Make TypeScript types more granular

### DIFF
--- a/ts/src/idl.ts
+++ b/ts/src/idl.ts
@@ -111,7 +111,7 @@ type IdlEnumFieldsNamed = IdlField[];
 
 type IdlEnumFieldsTuple = IdlType[];
 
-type IdlErrorCode = {
+export type IdlErrorCode = {
   code: number;
   name: string;
   msg?: string;

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -17,7 +17,7 @@ import workspace from "./workspace";
 import * as utils from "./utils";
 import { Program } from "./program";
 import { Address } from "./program/common";
-import { Event } from "./program/event";
+import { Event, EventParser } from "./program/event";
 import {
   ProgramAccount,
   AccountNamespace,
@@ -67,4 +67,5 @@ export {
   utils,
   Wallet,
   Address,
+  EventParser,
 };

--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -17,7 +17,7 @@ import workspace from "./workspace";
 import * as utils from "./utils";
 import { Program } from "./program";
 import { Address } from "./program/common";
-import { Event, EventParser } from "./program/event";
+import { Event } from "./program/event";
 import {
   ProgramAccount,
   AccountNamespace,
@@ -67,5 +67,4 @@ export {
   utils,
   Wallet,
   Address,
-  EventParser,
 };

--- a/ts/src/program/context.ts
+++ b/ts/src/program/context.ts
@@ -5,16 +5,16 @@ import {
   TransactionInstruction,
 } from "@solana/web3.js";
 import { Address } from "./common";
-import { IdlInstruction } from "../idl";
+import { IdlAccountItem, IdlAccounts, IdlInstruction } from "../idl";
 
 /**
  * Context provides all non-argument inputs for generating Anchor transactions.
  */
-export type Context = {
+export type Context<A extends Accounts = Accounts> = {
   /**
    * Accounts used in the instruction context.
    */
-  accounts?: Accounts;
+  accounts?: A;
 
   /**
    * All accounts to pass into an instruction *after* the main `accounts`.
@@ -55,9 +55,13 @@ export type Context = {
  * If multiple accounts are nested in the rust program, then they should be
  * nested here.
  */
-export type Accounts = {
-  [key: string]: Address | Accounts;
+export type Accounts<A extends IdlAccountItem[] = IdlAccountItem[]> = {
+  [K in A[number]["name"]]: Account<A[number]>;
 };
+
+type Account<A extends IdlAccountItem> = A extends IdlAccounts
+  ? Accounts<NonNullable<A["accounts"]>>
+  : Address;
 
 export function splitArgsAndCtx(
   idlIx: IdlInstruction,

--- a/ts/src/program/context.ts
+++ b/ts/src/program/context.ts
@@ -55,12 +55,12 @@ export type Context<A extends Accounts = Accounts> = {
  * If multiple accounts are nested in the rust program, then they should be
  * nested here.
  */
-export type Accounts<A extends IdlAccountItem[] = IdlAccountItem[]> = {
-  [K in A[number]["name"]]: Account<A[number]>;
+export type Accounts<A extends IdlAccountItem = IdlAccountItem> = {
+  [N in A["name"]]: Account<A & { name: N }>;
 };
 
 type Account<A extends IdlAccountItem> = A extends IdlAccounts
-  ? Accounts<NonNullable<A["accounts"]>>
+  ? Accounts<A["accounts"][number]>
   : Address;
 
 export function splitArgsAndCtx(

--- a/ts/src/program/event.ts
+++ b/ts/src/program/event.ts
@@ -1,13 +1,22 @@
 import { PublicKey } from "@solana/web3.js";
 import * as assert from "assert";
+import { IdlEvent, IdlEventField } from "src/idl";
 import Coder from "../coder";
+import { DecodeType } from "./namespace/types";
 
 const LOG_START_INDEX = "Program log: ".length;
 
 // Deserialized event.
-export type Event = {
-  name: string;
-  data: Object;
+export type Event<
+  E extends IdlEvent = IdlEvent,
+  Defined = Record<string, never>
+> = {
+  name: E["name"];
+  data: EventData<E["fields"][number], Defined>;
+};
+
+type EventData<T extends IdlEventField, Defined> = {
+  [N in T["name"]]: DecodeType<(T & { name: N })["type"], Defined>;
 };
 
 export class EventParser {

--- a/ts/src/program/index.ts
+++ b/ts/src/program/index.ts
@@ -73,7 +73,7 @@ export class Program<IDL extends Idl = Idl> {
    * });
    * ```
    */
-  readonly rpc: RpcNamespace<IDL>;
+  readonly rpc: RpcNamespace<IDL, IDL["instructions"][number]>;
 
   /**
    * The namespace provides handles to an [[AccountClient]] object for each
@@ -95,7 +95,7 @@ export class Program<IDL extends Idl = Idl> {
    *
    * For the full API, see the [[AccountClient]] reference.
    */
-  readonly account: AccountNamespace;
+  readonly account: AccountNamespace<IDL>;
 
   /**
    * The namespace provides functions to build [[TransactionInstruction]]
@@ -126,7 +126,7 @@ export class Program<IDL extends Idl = Idl> {
    * });
    * ```
    */
-  readonly instruction: InstructionNamespace<IDL>;
+  readonly instruction: InstructionNamespace<IDL, IDL["instructions"][number]>;
 
   /**
    * The namespace provides functions to build [[Transaction]] objects for each
@@ -157,7 +157,7 @@ export class Program<IDL extends Idl = Idl> {
    * });
    * ```
    */
-  readonly transaction: TransactionNamespace<IDL>;
+  readonly transaction: TransactionNamespace<IDL, IDL["instructions"][number]>;
 
   /**
    * The namespace provides functions to simulate transactions for each method
@@ -193,14 +193,14 @@ export class Program<IDL extends Idl = Idl> {
    * });
    * ```
    */
-  readonly simulate: SimulateNamespace<IDL>;
+  readonly simulate: SimulateNamespace<IDL, IDL["instructions"][number]>;
 
   /**
    * A client for the program state. Similar to the base [[Program]] client,
    * one can use this to send transactions and read accounts for the state
    * abstraction.
    */
-  readonly state: StateClient;
+  readonly state: StateClient<IDL>;
 
   /**
    * Address of the program.

--- a/ts/src/program/index.ts
+++ b/ts/src/program/index.ts
@@ -42,7 +42,7 @@ import { Address, translateAddress } from "./common";
  * below will refer to the two counter examples found
  * [here](https://github.com/project-serum/anchor#examples).
  */
-export class Program {
+export class Program<IDL extends Idl = Idl> {
   /**
    * Async methods to send signed transactions to *non*-state methods on the
    * program, returning a [[TransactionSignature]].
@@ -73,7 +73,7 @@ export class Program {
    * });
    * ```
    */
-  readonly rpc: RpcNamespace;
+  readonly rpc: RpcNamespace<IDL>;
 
   /**
    * The namespace provides handles to an [[AccountClient]] object for each
@@ -126,7 +126,7 @@ export class Program {
    * });
    * ```
    */
-  readonly instruction: InstructionNamespace;
+  readonly instruction: InstructionNamespace<IDL>;
 
   /**
    * The namespace provides functions to build [[Transaction]] objects for each
@@ -157,7 +157,7 @@ export class Program {
    * });
    * ```
    */
-  readonly transaction: TransactionNamespace;
+  readonly transaction: TransactionNamespace<IDL>;
 
   /**
    * The namespace provides functions to simulate transactions for each method
@@ -193,7 +193,7 @@ export class Program {
    * });
    * ```
    */
-  readonly simulate: SimulateNamespace;
+  readonly simulate: SimulateNamespace<IDL>;
 
   /**
    * A client for the program state. Similar to the base [[Program]] client,
@@ -213,10 +213,10 @@ export class Program {
   /**
    * IDL defining the program's interface.
    */
-  public get idl(): Idl {
+  public get idl(): IDL {
     return this._idl;
   }
-  private _idl: Idl;
+  private _idl: IDL;
 
   /**
    * Coder for serializing requests.
@@ -240,7 +240,7 @@ export class Program {
    * @param provider  The network and wallet context to use. If not provided
    *                  then uses [[getProvider]].
    */
-  public constructor(idl: Idl, programId: Address, provider?: Provider) {
+  public constructor(idl: IDL, programId: Address, provider?: Provider) {
     programId = translateAddress(programId);
 
     // Fields.
@@ -275,10 +275,13 @@ export class Program {
    * @param programId The on-chain address of the program.
    * @param provider  The network and wallet context.
    */
-  public static async at(address: Address, provider?: Provider) {
+  public static async at<IDL extends Idl = Idl>(
+    address: Address,
+    provider?: Provider
+  ) {
     const programId = translateAddress(address);
 
-    const idl = await Program.fetchIdl(programId, provider);
+    const idl = await Program.fetchIdl<IDL>(programId, provider);
     return new Program(idl, programId, provider);
   }
 
@@ -291,7 +294,10 @@ export class Program {
    * @param programId The on-chain address of the program.
    * @param provider  The network and wallet context.
    */
-  public static async fetchIdl(address: Address, provider?: Provider) {
+  public static async fetchIdl<IDL extends Idl = Idl>(
+    address: Address,
+    provider?: Provider
+  ): Promise<IDL> {
     provider = provider ?? getProvider();
     const programId = translateAddress(address);
 

--- a/ts/src/program/namespace/account.ts
+++ b/ts/src/program/namespace/account.ts
@@ -24,7 +24,7 @@ export default class AccountFactory {
     coder: Coder,
     programId: PublicKey,
     provider: Provider
-  ): AccountNamespace {
+  ): AccountNamespace<IDL> {
     const accountFns: AccountNamespace = {};
 
     idl.accounts.forEach((idlAccount) => {
@@ -38,7 +38,7 @@ export default class AccountFactory {
       );
     });
 
-    return accountFns;
+    return accountFns as AccountNamespace<IDL>;
   }
 }
 

--- a/ts/src/program/namespace/account.ts
+++ b/ts/src/program/namespace/account.ts
@@ -19,8 +19,8 @@ import { Subscription, Address, translateAddress } from "../common";
 import { getProvider } from "../../";
 
 export default class AccountFactory {
-  public static build(
-    idl: Idl,
+  public static build<IDL extends Idl>(
+    idl: IDL,
     coder: Coder,
     programId: PublicKey,
     provider: Provider
@@ -29,7 +29,7 @@ export default class AccountFactory {
 
     idl.accounts.forEach((idlAccount) => {
       const name = camelCase(idlAccount.name);
-      accountFns[name] = new AccountClient(
+      accountFns[name] = new AccountClient<IDL>(
         idl,
         idlAccount,
         programId,
@@ -62,11 +62,11 @@ export default class AccountFactory {
  *
  * For the full API, see the [[AccountClient]] reference.
  */
-export interface AccountNamespace {
-  [key: string]: AccountClient;
+export interface AccountNamespace<IDL extends Idl = Idl> {
+  [key: string]: AccountClient<IDL>;
 }
 
-export class AccountClient {
+export class AccountClient<IDL extends Idl = Idl> {
   /**
    * Returns the number of bytes in this account.
    */
@@ -99,11 +99,11 @@ export class AccountClient {
   }
   private _coder: Coder;
 
-  private _idlAccount: IdlTypeDef;
+  private _idlAccount: IDL["accounts"][number];
 
   constructor(
-    idl: Idl,
-    idlAccount: IdlTypeDef,
+    idl: IDL,
+    idlAccount: IDL["accounts"][number],
     programId: PublicKey,
     provider?: Provider,
     coder?: Coder

--- a/ts/src/program/namespace/index.ts
+++ b/ts/src/program/namespace/index.ts
@@ -10,6 +10,7 @@ import RpcFactory, { RpcNamespace } from "./rpc";
 import AccountFactory, { AccountNamespace } from "./account";
 import SimulateFactory, { SimulateNamespace } from "./simulate";
 import { parseIdlErrors } from "../common";
+import { AllInstructions } from "./types";
 
 // Re-exports.
 export { StateClient } from "./state";
@@ -32,9 +33,9 @@ export default class NamespaceFactory {
     RpcNamespace<IDL>,
     InstructionNamespace<IDL>,
     TransactionNamespace<IDL>,
-    AccountNamespace,
+    AccountNamespace<IDL>,
     SimulateNamespace<IDL>,
-    StateClient
+    StateClient<IDL>
   ] {
     const rpc: RpcNamespace = {};
     const instruction: InstructionNamespace = {};
@@ -45,8 +46,8 @@ export default class NamespaceFactory {
 
     const state = StateFactory.build(idl, coder, programId, provider);
 
-    idl.instructions.forEach(<I extends IdlInstruction>(idlIx: I) => {
-      const ixItem = InstructionFactory.build(
+    idl.instructions.forEach(<I extends AllInstructions<IDL>>(idlIx: I) => {
+      const ixItem = InstructionFactory.build<IDL, I>(
         idlIx,
         (ixName, ix) => coder.instruction.encode(ixName, ix),
         programId

--- a/ts/src/program/namespace/instruction.ts
+++ b/ts/src/program/namespace/instruction.ts
@@ -1,4 +1,8 @@
-import { PublicKey, TransactionInstruction } from "@solana/web3.js";
+import {
+  AccountMeta,
+  PublicKey,
+  TransactionInstruction,
+} from "@solana/web3.js";
 import { IdlAccount, IdlInstruction, IdlAccountItem } from "../../idl";
 import { IdlError } from "../../error";
 import {
@@ -48,17 +52,18 @@ export default class InstructionNamespaceFactory {
     return ix;
   }
 
-  public static accountsArray(ctx: Accounts, accounts: IdlAccountItem[]): any {
+  public static accountsArray(
+    ctx: Accounts,
+    accounts: IdlAccountItem[]
+  ): AccountMeta[] {
     return accounts
       .map((acc: IdlAccountItem) => {
         // Nested accounts.
-        // @ts-ignore
-        const nestedAccounts: IdlAccountItem[] | undefined = acc.accounts;
-        if (nestedAccounts !== undefined) {
+        if ("accounts" in acc) {
           const rpcAccs = ctx[acc.name] as Accounts;
           return InstructionNamespaceFactory.accountsArray(
             rpcAccs,
-            nestedAccounts
+            acc.accounts
           ).flat();
         } else {
           const account: IdlAccount = acc as IdlAccount;

--- a/ts/src/program/namespace/instruction.ts
+++ b/ts/src/program/namespace/instruction.ts
@@ -54,7 +54,7 @@ export default class InstructionNamespaceFactory {
 
   public static accountsArray(
     ctx: Accounts,
-    accounts: IdlAccountItem[]
+    accounts: readonly IdlAccountItem[]
   ): AccountMeta[] {
     return accounts
       .map((acc: IdlAccountItem) => {
@@ -118,7 +118,7 @@ export interface InstructionNamespace {
  */
 export type InstructionFn = IxProps & ((...args: any[]) => any);
 type IxProps = {
-  accounts: (ctx: Accounts) => any;
+  accounts: (ctx: Accounts) => readonly AccountMeta[];
 };
 
 export type InstructionEncodeFn = (ixName: string, ix: any) => Buffer;

--- a/ts/src/program/namespace/rpc.ts
+++ b/ts/src/program/namespace/rpc.ts
@@ -4,10 +4,14 @@ import { Idl, IdlInstruction } from "../../idl";
 import { splitArgsAndCtx } from "../context";
 import { TransactionFn } from "./transaction";
 import { ProgramError } from "../../error";
-import { InstructionContextFn, MakeInstructionsNamespace } from "./types";
+import {
+  AllInstructions,
+  InstructionContextFn,
+  MakeInstructionsNamespace,
+} from "./types";
 
 export default class RpcFactory {
-  public static build<IDL extends Idl, I extends IDL["instructions"][number]>(
+  public static build<IDL extends Idl, I extends AllInstructions<IDL>>(
     idlIx: I,
     txFn: TransactionFn<IDL, I>,
     idlErrors: Map<number, string>,
@@ -67,11 +71,10 @@ export default class RpcFactory {
  * });
  * ```
  */
-export type RpcNamespace<IDL extends Idl = Idl> = MakeInstructionsNamespace<
-  IDL,
-  IDL["instructions"][number],
-  Promise<TransactionSignature>
->;
+export type RpcNamespace<
+  IDL extends Idl = Idl,
+  I extends AllInstructions<IDL> = AllInstructions<IDL>
+> = MakeInstructionsNamespace<IDL, I, Promise<TransactionSignature>>;
 
 /**
  * RpcFn is a single RPC method generated from an IDL, sending a transaction
@@ -79,5 +82,5 @@ export type RpcNamespace<IDL extends Idl = Idl> = MakeInstructionsNamespace<
  */
 export type RpcFn<
   IDL extends Idl = Idl,
-  I extends IDL["instructions"][number] = IDL["instructions"][number]
+  I extends AllInstructions<IDL> = AllInstructions<IDL>
 > = InstructionContextFn<IDL, I, Promise<TransactionSignature>>;

--- a/ts/src/program/namespace/rpc.ts
+++ b/ts/src/program/namespace/rpc.ts
@@ -1,18 +1,19 @@
 import { TransactionSignature } from "@solana/web3.js";
 import Provider from "../../provider";
-import { IdlInstruction } from "../../idl";
+import { Idl, IdlInstruction } from "../../idl";
 import { splitArgsAndCtx } from "../context";
 import { TransactionFn } from "./transaction";
 import { ProgramError } from "../../error";
+import { InstructionContextFn, MakeInstructionsNamespace } from "./types";
 
 export default class RpcFactory {
-  public static build(
-    idlIx: IdlInstruction,
-    txFn: TransactionFn,
+  public static build<IDL extends Idl, I extends IDL["instructions"][number]>(
+    idlIx: I,
+    txFn: TransactionFn<IDL, I>,
     idlErrors: Map<number, string>,
     provider: Provider
   ): RpcFn {
-    const rpc = async (...args: any[]): Promise<TransactionSignature> => {
+    const rpc: RpcFn<IDL, I> = async (...args) => {
       const tx = txFn(...args);
       const [, ctx] = splitArgsAndCtx(idlIx, [...args]);
       try {
@@ -66,12 +67,17 @@ export default class RpcFactory {
  * });
  * ```
  */
-export interface RpcNamespace {
-  [key: string]: RpcFn;
-}
+export type RpcNamespace<IDL extends Idl = Idl> = MakeInstructionsNamespace<
+  IDL,
+  IDL["instructions"][number],
+  Promise<TransactionSignature>
+>;
 
 /**
  * RpcFn is a single RPC method generated from an IDL, sending a transaction
  * paid for and signed by the configured provider.
  */
-export type RpcFn = (...args: any[]) => Promise<TransactionSignature>;
+export type RpcFn<
+  IDL extends Idl = Idl,
+  I extends IDL["instructions"][number] = IDL["instructions"][number]
+> = InstructionContextFn<IDL, I, Promise<TransactionSignature>>;

--- a/ts/src/program/namespace/simulate.ts
+++ b/ts/src/program/namespace/simulate.ts
@@ -10,7 +10,7 @@ import {
   AllInstructions,
   IdlTypes,
   InstructionContextFn,
-  MakeAllInstructionsNamespace,
+  MakeInstructionsNamespace,
 } from "./types";
 import { Event } from "../event";
 
@@ -98,9 +98,11 @@ export default class SimulateFactory {
  * ```
  */
 export type SimulateNamespace<
-  IDL extends Idl = Idl
-> = MakeAllInstructionsNamespace<
+  IDL extends Idl = Idl,
+  I extends AllInstructions<IDL> = AllInstructions<IDL>
+> = MakeInstructionsNamespace<
   IDL,
+  I,
   Promise<SimulateResponse<IDL["events"][number], IdlTypes<IDL>>>
 >;
 

--- a/ts/src/program/namespace/state.ts
+++ b/ts/src/program/namespace/state.ts
@@ -18,6 +18,7 @@ import { Accounts } from "../context";
 import InstructionNamespaceFactory from "./instruction";
 import RpcNamespaceFactory from "./rpc";
 import TransactionNamespaceFactory from "./transaction";
+import { IdlTypes, TypeDef } from "./types";
 
 export default class StateFactory {
   public static build<IDL extends Idl>(
@@ -38,7 +39,10 @@ export default class StateFactory {
  * one can use this to send transactions and read accounts for the state
  * abstraction.
  */
-export class StateClient<IDL extends Idl> {
+export class StateClient<
+  IDL extends Idl,
+  T = TypeDef<IDL["state"]["struct"], IdlTypes<IDL>>
+> {
   /**
    * [[RpcNamespace]] for all state methods.
    */
@@ -163,7 +167,7 @@ export class StateClient<IDL extends Idl> {
   /**
    * Returns the deserialized state account.
    */
-  async fetch(): Promise<Object> {
+  async fetch(): Promise<T> {
     const addr = this.address();
     const accountInfo = await this.provider.connection.getAccountInfo(addr);
     if (accountInfo === null) {

--- a/ts/src/program/namespace/transaction.ts
+++ b/ts/src/program/namespace/transaction.ts
@@ -5,7 +5,7 @@ import { InstructionFn } from "./instruction";
 import {
   AllInstructions,
   InstructionContextFn,
-  MakeAllInstructionsNamespace,
+  MakeInstructionsNamespace,
 } from "./types";
 
 export default class TransactionFactory {
@@ -57,8 +57,9 @@ export default class TransactionFactory {
  * ```
  */
 export type TransactionNamespace<
-  IDL extends Idl = Idl
-> = MakeAllInstructionsNamespace<IDL, Transaction>;
+  IDL extends Idl = Idl,
+  I extends AllInstructions<IDL> = AllInstructions<IDL>
+> = MakeInstructionsNamespace<IDL, I, Transaction>;
 
 /**
  * Tx is a function to create a `Transaction` for a given program instruction.

--- a/ts/src/program/namespace/transaction.ts
+++ b/ts/src/program/namespace/transaction.ts
@@ -1,14 +1,19 @@
 import { Transaction } from "@solana/web3.js";
-import { IdlInstruction } from "../../idl";
+import { Idl, IdlInstruction } from "../../idl";
 import { splitArgsAndCtx } from "../context";
 import { InstructionFn } from "./instruction";
+import {
+  AllInstructions,
+  InstructionContextFn,
+  MakeAllInstructionsNamespace,
+} from "./types";
 
 export default class TransactionFactory {
-  public static build(
-    idlIx: IdlInstruction,
-    ixFn: InstructionFn
-  ): TransactionFn {
-    const txFn = (...args: any[]): Transaction => {
+  public static build<IDL extends Idl, I extends AllInstructions<IDL>>(
+    idlIx: I,
+    ixFn: InstructionFn<IDL, I>
+  ): TransactionFn<IDL, I> {
+    const txFn: TransactionFn<IDL, I> = (...args): Transaction => {
       const [, ctx] = splitArgsAndCtx(idlIx, [...args]);
       const tx = new Transaction();
       if (ctx.instructions !== undefined) {
@@ -51,11 +56,14 @@ export default class TransactionFactory {
  * });
  * ```
  */
-export interface TransactionNamespace {
-  [key: string]: TransactionFn;
-}
+export type TransactionNamespace<
+  IDL extends Idl = Idl
+> = MakeAllInstructionsNamespace<IDL, Transaction>;
 
 /**
  * Tx is a function to create a `Transaction` for a given program instruction.
  */
-export type TransactionFn = (...args: any[]) => Transaction;
+export type TransactionFn<
+  IDL extends Idl = Idl,
+  I extends AllInstructions<IDL> = AllInstructions<IDL>
+> = InstructionContextFn<IDL, I, Transaction>;

--- a/ts/src/program/namespace/types.ts
+++ b/ts/src/program/namespace/types.ts
@@ -1,0 +1,110 @@
+import { PublicKey, TransactionInstruction } from "@solana/web3.js";
+import BN from "bn.js";
+import { Idl } from "src";
+import { IdlField, IdlInstruction, IdlType, IdlTypeDef } from "../../idl";
+import { Accounts, Context } from "../context";
+
+/**
+ * All instructions for an IDL.
+ */
+export type AllInstructions<IDL extends Idl> = IDL["instructions"][number] &
+  IDL["state"]["methods"][number];
+
+/**
+ * Returns a type of instruction name to the IdlInstruction.
+ */
+export type InstructionMap<I extends IdlInstruction> = {
+  [K in I["name"]]: I & { name: K };
+};
+
+/**
+ * Returns a type of instruction name to the IdlInstruction.
+ */
+export type AllInstructionsMap<IDL extends Idl> = InstructionMap<
+  AllInstructions<IDL>
+>;
+
+export type MakeAllInstructionsNamespace<
+  IDL extends Idl,
+  Ret,
+  Mk extends { [M in keyof InstructionMap<AllInstructions<IDL>>]: unknown } = {
+    [M in keyof InstructionMap<AllInstructions<IDL>>]: unknown;
+  }
+> = MakeInstructionsNamespace<IDL, AllInstructions<IDL>, Ret, Mk>;
+
+export type MakeInstructionsNamespace<
+  IDL extends Idl,
+  I extends IdlInstruction,
+  Ret,
+  Mk extends { [M in keyof InstructionMap<I>]: unknown } = {
+    [M in keyof InstructionMap<I>]: unknown;
+  }
+> = {
+  [M in keyof InstructionMap<I>]: InstructionContextFn<
+    IDL,
+    InstructionMap<I>[M],
+    Ret
+  > &
+    Mk[M];
+};
+
+export type InstructionContextFnArgs<
+  IDL extends Idl,
+  I extends IDL["instructions"][number]
+> = [...ArgsTuple<I["args"], IdlTypes<IDL>>, Context<Accounts<I["accounts"]>>];
+
+export type InstructionContextFn<
+  IDL extends Idl,
+  I extends IDL["instructions"][number],
+  Ret
+> = (...args: InstructionContextFnArgs<IDL, I>) => Ret;
+
+type TypeMap = {
+  publicKey: PublicKey;
+  u64: BN;
+  i64: BN;
+} & {
+  [K in "u8" | "i8" | "u16" | "i16" | "u32" | "i32"]: number;
+};
+
+export type DecodeType<T extends IdlType, Defined> = T extends keyof TypeMap
+  ? TypeMap[T]
+  : T extends { defined: keyof Defined }
+  ? Defined[T["defined"]]
+  : T extends { option: { defined: keyof Defined } }
+  ? Defined[T["option"]["defined"]] | null
+  : T extends { vec: { defined: keyof Defined } }
+  ? Defined[T["vec"]["defined"]][]
+  : unknown;
+
+/**
+ * Tuple of arguments
+ */
+type ArgsTuple<A extends IdlField[], Defined> = {
+  [K in keyof A]: A[K] extends IdlField
+    ? DecodeType<A[K]["type"], Defined>
+    : unknown;
+} &
+  unknown[];
+
+type FieldsOfType<I extends IdlTypeDef> = NonNullable<
+  I["type"]["fields"]
+>[number];
+
+type TypeDef<I extends IdlTypeDef, Defined> = {
+  [F in FieldsOfType<I>["name"]]: DecodeType<
+    (FieldsOfType<I> & { name: F })["type"],
+    Defined
+  >;
+};
+
+type TypeDefDictionary<T extends IdlTypeDef[], Defined> = {
+  [K in T[number]["name"]]: TypeDef<T[number] & { name: K }, Defined>;
+};
+
+export type IdlTypes<T extends Idl> = TypeDefDictionary<
+  NonNullable<T["types"]>,
+  Record<string, never>
+>;
+
+export type IdlErrorInfo<IDL extends Idl> = NonNullable<IDL["errors"]>[number];

--- a/ts/src/program/namespace/types.ts
+++ b/ts/src/program/namespace/types.ts
@@ -1,4 +1,4 @@
-import { PublicKey, TransactionInstruction } from "@solana/web3.js";
+import { PublicKey } from "@solana/web3.js";
 import BN from "bn.js";
 import { Idl } from "src";
 import { IdlField, IdlInstruction, IdlType, IdlTypeDef } from "../../idl";
@@ -86,7 +86,7 @@ type FieldsOfType<I extends IdlTypeDef> = NonNullable<
   I["type"]["fields"]
 >[number];
 
-type TypeDef<I extends IdlTypeDef, Defined> = {
+export type TypeDef<I extends IdlTypeDef, Defined> = {
   [F in FieldsOfType<I>["name"]]: DecodeType<
     (FieldsOfType<I> & { name: F })["type"],
     Defined

--- a/ts/src/program/namespace/types.ts
+++ b/ts/src/program/namespace/types.ts
@@ -24,14 +24,6 @@ export type AllInstructionsMap<IDL extends Idl> = InstructionMap<
   AllInstructions<IDL>
 >;
 
-export type MakeAllInstructionsNamespace<
-  IDL extends Idl,
-  Ret,
-  Mk extends { [M in keyof InstructionMap<AllInstructions<IDL>>]: unknown } = {
-    [M in keyof InstructionMap<AllInstructions<IDL>>]: unknown;
-  }
-> = MakeInstructionsNamespace<IDL, AllInstructions<IDL>, Ret, Mk>;
-
 export type MakeInstructionsNamespace<
   IDL extends Idl,
   I extends IdlInstruction,
@@ -51,11 +43,14 @@ export type MakeInstructionsNamespace<
 export type InstructionContextFnArgs<
   IDL extends Idl,
   I extends IDL["instructions"][number]
-> = [...ArgsTuple<I["args"], IdlTypes<IDL>>, Context<Accounts<I["accounts"]>>];
+> = [
+  ...ArgsTuple<I["args"], IdlTypes<IDL>>,
+  Context<Accounts<I["accounts"][number]>>
+];
 
 export type InstructionContextFn<
   IDL extends Idl,
-  I extends IDL["instructions"][number],
+  I extends AllInstructions<IDL>,
   Ret
 > = (...args: InstructionContextFnArgs<IDL, I>) => Ret;
 


### PR DESCRIPTION
Adds types which are based on `Idl`. Theoretically these shouldn't be breaking, as they extend the original types.