### PR TITLE
cli: add ability to pass features to cargo build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ incremented for features.
 
 ## [Unreleased]
 
+## Features
+
+* cli: Add ability to pass feature flags to `cargo build`.
+
 ## [0.10.0] - 2021-06-27
 
 ### Features


### PR DESCRIPTION
This adds the ability for developers to pass along features to `cargo build` when using the `anchor-cli` e.g. 
- `anchor build --cargo-features {x}`
- `anchor test -c {x},{y}`

Alternatively we could pass in `cargo build` arguments as raw arguments i.e.
- `anchor build -- --features {x}`
- `anchor test -- --features {x},{y}`

