### PR TITLE
docs: Add tutorial-6 to sidebar

### DIFF
--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -65,6 +65,7 @@ module.exports = {
           "/tutorials/tutorial-3",
           "/tutorials/tutorial-4",
           "/tutorials/tutorial-5",
+          "/tutorials/tutorial-6",
         ],
       },
       {


### PR DESCRIPTION
trivial fix, the associated accounts tutorial isnt on the sidebar