### PR TITLE
Update Tutorial 1 Code to Match Docs

### DIFF
--- a/examples/tutorial/basic-1/programs/basic-1/src/lib.rs
+++ b/examples/tutorial/basic-1/programs/basic-1/src/lib.rs
@@ -22,7 +22,7 @@ mod basic_1 {
 #[derive(Accounts)]
 pub struct Initialize<'info> {
     #[account(init, payer = user, space = 8 + 8)]
-    pub my_account: Account<'info, MyAccount>,
+    pub my_account: ProgramAccount<'info, MyAccount>,
     #[account(mut)]
     pub user: Signer<'info>,
     pub system_program: Program<'info, System>,
@@ -31,7 +31,7 @@ pub struct Initialize<'info> {
 #[derive(Accounts)]
 pub struct Update<'info> {
     #[account(mut)]
-    pub my_account: Account<'info, MyAccount>,
+    pub my_account: ProgramAccount<'info, MyAccount>,
 }
 
 #[account]


### PR DESCRIPTION
The docs mentioned that we used `ProgramAccount` in tutorial 1 to make sure that the account was owned by the current program, but the code sample didn't reflect that. Updated the code sample to match the docs.