### PR TITLE
WIP on #798: nicer error logs

### DIFF
--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -88,6 +88,30 @@ pub use anchor_derive_accounts::Accounts;
 pub use borsh::{BorshDeserialize as AnchorDeserialize, BorshSerialize as AnchorSerialize};
 pub use solana_program;
 
+pub trait AnchorError: std::fmt::Display {
+    fn to_program_error(&self) -> solana_program::program_error::ProgramError;
+}
+
+impl<E: Into<ProgramError> + Clone + std::fmt::Display> AnchorError for E {
+    fn to_program_error(&self) -> solana_program::program_error::ProgramError {
+        self.clone().into()
+    }
+}
+
+impl<E: AnchorError + 'static> From<E> for Box<dyn AnchorError> {
+    fn from(e: E) -> Self {
+        Box::new(e)
+    }
+}
+
+impl From<Box<dyn AnchorError>> for solana_program::program_error::ProgramError {
+    fn from(e: Box<dyn AnchorError>) -> solana_program::program_error::ProgramError {
+        e.into()
+    }
+}
+
+pub type DynAnchorResult = std::result::Result<(), Box<dyn AnchorError>>;
+
 /// A data structure of validated accounts that can be deserialized from the
 /// input to a Solana program. Implementations of this trait should perform any
 /// and all requisite constraint checks on accounts to ensure the accounts

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -307,7 +307,7 @@ pub mod __private {
     use solana_program::pubkey::Pubkey;
 
     pub use crate::ctor::Ctor;
-    pub use crate::error::{Error, ErrorCode};
+    pub use crate::error::{Error, ErrorCode, __pretty_print_error_code};
     pub use anchor_attribute_account::ZeroCopyAccessor;
     pub use anchor_attribute_event::EventIndex;
     pub use base64;

--- a/lang/syn/src/codegen/error.rs
+++ b/lang/syn/src/codegen/error.rs
@@ -34,7 +34,7 @@ pub fn generate(error: Error) -> proc_macro2::TokenStream {
                 #enum_name::#ident => #msg
             };
             let code_dispatch = quote! {
-                #error_code_id => ::anchor_lang::solana_program::msg!("{}", #enum_name::#ident)
+                #error_code_id => Some(format!("{}", #enum_name::#ident))
             };
             (variant_dispatch, code_dispatch)
         })
@@ -54,10 +54,10 @@ pub fn generate(error: Error) -> proc_macro2::TokenStream {
         /// program.
         pub type Result<T> = std::result::Result<T, Error>;
 
-        pub fn __pretty_print_error_code(code: u32) {
+        pub fn __pretty_print_error_code(code: u32) -> Option<String> {
             match code - #offset {
                 #(#code_dispatch),*
-                , _ => {}
+                , _ => None
             }
         }
 

--- a/lang/syn/src/codegen/error.rs
+++ b/lang/syn/src/codegen/error.rs
@@ -49,7 +49,7 @@ pub fn generate(error: Error) -> proc_macro2::TokenStream {
         /// `ProgramError` or a custom, user defined error code by utilizing
         /// its `From` implementation.
         #[doc(hidden)]
-        #[derive(thiserror::Error, Debug)]
+        #[derive(thiserror::Error, Clone, Debug)]
         pub enum Error {
             #[error(transparent)]
             ProgramError(#[from] anchor_lang::solana_program::program_error::ProgramError),

--- a/lang/syn/src/codegen/program/dispatch.rs
+++ b/lang/syn/src/codegen/program/dispatch.rs
@@ -18,7 +18,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                             program_id,
                             accounts,
                             ix_data,
-                        )
+                        ).map_err(Into::into)
                     }
                 }
             }
@@ -47,7 +47,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                     program_id,
                                     accounts,
                                     ix_data,
-                                )
+                                ).map_err(Into::into)
                             }
                         }
                     })
@@ -82,7 +82,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                             program_id,
                                             accounts,
                                             ix_data,
-                                        )
+                                        ).map_err(Into::into)
                                     }
                                 }
                             })
@@ -108,7 +108,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                         program_id,
                         accounts,
                         ix_data,
-                    )
+                    ).map_err(Into::into)
                 }
             }
         })
@@ -139,7 +139,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             program_id: &Pubkey,
             accounts: &[AccountInfo],
             data: &[u8],
-        ) -> ProgramResult {
+        ) -> ::anchor_lang::DynAnchorResult {
             // Split the instruction data into the first 8 byte method
             // identifier (sighash) and the serialized instruction data.
             let mut ix_data: &[u8] = data;
@@ -158,7 +158,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                         program_id,
                         accounts,
                         &ix_data,
-                    );
+                    ).map_err(Into::into);
                 }
             }
 
@@ -181,7 +181,7 @@ pub fn gen_fallback(program: &Program) -> Option<proc_macro2::TokenStream> {
         let method = &fallback_fn.raw_method;
         let fn_name = &method.sig.ident;
         quote! {
-            #program_name::#fn_name(program_id, accounts, data)
+            #program_name::#fn_name(program_id, accounts, data).map_err(Into::into)
         }
     })
 }

--- a/lang/syn/src/codegen/program/entry.rs
+++ b/lang/syn/src/codegen/program/entry.rs
@@ -63,13 +63,13 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
 
             dispatch(program_id, accounts, data)
                 .map_err(|e| {
-                    anchor_lang::solana_program::msg!(&e.to_string());
                     let program_error = e.to_program_error();
-                    match program_error {
-                        ::anchor_lang::solana_program::program_error::ProgramError::Custom(code) => {
-                            anchor_lang::__private::__pretty_print_error_code(code)
-                        },
-                        _ => anchor_lang::solana_program::msg!(&program_error.to_string())
+                    anchor_lang::solana_program::msg!(&program_error.to_string());
+                    if let ::anchor_lang::solana_program::program_error::ProgramError::Custom(code) = program_error {
+                        match anchor_lang::__private::__pretty_print_error_code(code) {
+                            Some(s) => anchor_lang::solana_program::msg!(&s),
+                            None => anchor_lang::solana_program::msg!(&e.to_string())
+                        }
                     }
                     program_error
                 })

--- a/lang/syn/src/codegen/program/entry.rs
+++ b/lang/syn/src/codegen/program/entry.rs
@@ -65,7 +65,12 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 .map_err(|e| {
                     anchor_lang::solana_program::msg!(&e.to_string());
                     let program_error = e.to_program_error();
-                    anchor_lang::solana_program::msg!(&program_error.to_string());
+                    match program_error {
+                        ::anchor_lang::solana_program::program_error::ProgramError::Custom(code) => {
+                            anchor_lang::__private::__pretty_print_error_code(code)
+                        },
+                        _ => anchor_lang::solana_program::msg!(&program_error.to_string())
+                    }
                     program_error
                 })
         }

--- a/lang/syn/src/codegen/program/entry.rs
+++ b/lang/syn/src/codegen/program/entry.rs
@@ -64,7 +64,9 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             dispatch(program_id, accounts, data)
                 .map_err(|e| {
                     anchor_lang::solana_program::msg!(&e.to_string());
-                    e
+                    let program_error = e.to_program_error();
+                    anchor_lang::solana_program::msg!(&program_error.to_string());
+                    program_error
                 })
         }
 

--- a/lang/syn/src/codegen/program/handlers.rs
+++ b/lang/syn/src/codegen/program/handlers.rs
@@ -16,7 +16,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             // on chain.
             #[inline(never)]
             #[cfg(not(feature = "no-idl"))]
-            pub fn __idl_dispatch(program_id: &Pubkey, accounts: &[AccountInfo], idl_ix_data: &[u8]) -> ProgramResult {
+            pub fn __idl_dispatch(program_id: &Pubkey, accounts: &[AccountInfo], idl_ix_data: &[u8]) -> ::anchor_lang::DynAnchorResult {
                 let mut accounts = accounts;
                 let mut data: &[u8] = idl_ix_data;
 
@@ -60,7 +60,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
 
             #[inline(never)]
             #[cfg(feature = "no-idl")]
-            pub fn __idl_dispatch(program_id: &Pubkey, accounts: &[AccountInfo], idl_ix_data: &[u8]) -> ProgramResult {
+            pub fn __idl_dispatch(program_id: &Pubkey, accounts: &[AccountInfo], idl_ix_data: &[u8]) -> ::anchor_lang::DynAnchorResult {
                 Err(anchor_lang::__private::ErrorCode::IdlInstructionStub.into())
             }
 
@@ -71,7 +71,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 program_id: &Pubkey,
                 accounts: &mut anchor_lang::idl::IdlCreateAccounts,
                 data_len: u64,
-            ) -> ProgramResult {
+            ) -> ::anchor_lang::DynAnchorResult {
                 if program_id != accounts.program.key {
                     return Err(anchor_lang::__private::ErrorCode::IdlInstructionInvalidProgram.into());
                 }
@@ -131,7 +131,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             pub fn __idl_create_buffer(
                 program_id: &Pubkey,
                 accounts: &mut anchor_lang::idl::IdlCreateBuffer,
-            ) -> ProgramResult {
+            ) -> ::anchor_lang::DynAnchorResult {
                 let mut buffer = &mut accounts.buffer;
                 buffer.authority = *accounts.authority.key;
                 Ok(())
@@ -142,7 +142,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 program_id: &Pubkey,
                 accounts: &mut anchor_lang::idl::IdlAccounts,
                 idl_data: Vec<u8>,
-            ) -> ProgramResult {
+            ) -> ::anchor_lang::DynAnchorResult {
                 let mut idl = &mut accounts.idl;
                 idl.data.extend(idl_data);
                 Ok(())
@@ -153,7 +153,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                 program_id: &Pubkey,
                 accounts: &mut anchor_lang::idl::IdlAccounts,
                 new_authority: Pubkey,
-            ) -> ProgramResult {
+            ) -> ::anchor_lang::DynAnchorResult {
                 accounts.idl.authority = new_authority;
                 Ok(())
             }
@@ -162,7 +162,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
             pub fn __idl_set_buffer(
                 program_id: &Pubkey,
                 accounts: &mut anchor_lang::idl::IdlSetBuffer,
-            ) -> ProgramResult {
+            ) -> ::anchor_lang::DynAnchorResult {
                 accounts.idl.data = accounts.buffer.data.clone();
                 Ok(())
             }
@@ -185,7 +185,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                         // One time state account initializer. Will faill on subsequent
                         // invocations.
                         #[inline(never)]
-                        pub fn __ctor(program_id: &Pubkey, accounts: &[AccountInfo], ix_data: &[u8]) -> ProgramResult {
+                        pub fn __ctor(program_id: &Pubkey, accounts: &[AccountInfo], ix_data: &[u8]) -> ::anchor_lang::DynAnchorResult {
                             // Deserialize instruction data.
                             let ix = instruction::state::#ix_name::deserialize(&mut &ix_data[..])
                                 .map_err(|_| anchor_lang::__private::ErrorCode::InstructionDidNotDeserialize)?;
@@ -256,7 +256,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                         // One time state account initializer. Will faill on subsequent
                         // invocations.
                         #[inline(never)]
-                        pub fn __ctor(program_id: &Pubkey, accounts: &[AccountInfo], ix_data: &[u8]) -> ProgramResult {
+                        pub fn __ctor(program_id: &Pubkey, accounts: &[AccountInfo], ix_data: &[u8]) -> ::anchor_lang::DynAnchorResult {
                             // Deserialize instruction data.
                             let ix = instruction::state::#ix_name::deserialize(&mut &ix_data[..])
                                 .map_err(|_| anchor_lang::__private::ErrorCode::InstructionDidNotDeserialize)?;
@@ -355,7 +355,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                     program_id: &Pubkey,
                                     accounts: &[AccountInfo],
                                     ix_data: &[u8],
-                                ) -> ProgramResult {
+                                ) -> ::anchor_lang::DynAnchorResult {
                                     // Deserialize instruction.
                                     let ix = instruction::state::#ix_name::deserialize(&mut &ix_data[..])
                                         .map_err(|_| anchor_lang::__private::ErrorCode::InstructionDidNotDeserialize)?;
@@ -398,7 +398,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                     program_id: &Pubkey,
                                     accounts: &[AccountInfo],
                                     ix_data: &[u8],
-                                ) -> ProgramResult {
+                                ) -> ::anchor_lang::DynAnchorResult {
                                     // Deserialize instruction.
                                     let ix = instruction::state::#ix_name::deserialize(&mut &ix_data[..])
                                         .map_err(|_| anchor_lang::__private::ErrorCode::InstructionDidNotDeserialize)?;
@@ -510,7 +510,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                             program_id: &Pubkey,
                                             accounts: &[AccountInfo],
                                             ix_data: &[u8],
-                                        ) -> ProgramResult {
+                                        ) -> ::anchor_lang::DynAnchorResult {
                                             // Deserialize instruction.
                                             #deserialize_instruction
 
@@ -554,7 +554,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                                             program_id: &Pubkey,
                                             accounts: &[AccountInfo],
                                             ix_data: &[u8],
-                                        ) -> ProgramResult {
+                                        ) -> ::anchor_lang::DynAnchorResult {
                                             // Deserialize instruction.
                                             #deserialize_instruction
 
@@ -600,7 +600,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                     program_id: &Pubkey,
                     accounts: &[AccountInfo],
                     ix_data: &[u8],
-                ) -> ProgramResult {
+                ) -> ::anchor_lang::DynAnchorResult {
                     // Deserialize data.
                     let ix = instruction::#ix_name::deserialize(&mut &ix_data[..])
                         .map_err(|_| anchor_lang::__private::ErrorCode::InstructionDidNotDeserialize)?;
@@ -621,7 +621,9 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
                     )?;
 
                     // Exit routine.
-                    accounts.exit(program_id)
+                    accounts.exit(program_id)?;
+
+                    Ok(())
                 }
             }
         })


### PR DESCRIPTION
#798 

This is pretty rough but I think I need to hurry up and start a PR, oof. I think just about all tests are passing except for `lockup`, which doesn't even build, but I can't seem to find why its registry `#[program]` is unhappy.

There are two ideas:

First idea: Box up behind a dyn trait the various different error enums that can show up in an anchor program (low-level Solana ProgramErrors, Anchor's framework ErrorCode enum, Anchor's wrapper Error enum, your own custom errors, etc.). In principle it ought to be possible to avoid this dynamic dispatch approach but I'm not sure how to actually do it :/

Second idea/huge hack: Anchor's built-in traits (`Accounts`, `AccountsExit`, etc.) all return `ProgramResult`s. This means that internal Anchor ErrorCodes get smooshed into `ProgramError::Custom(u32)`s, throwing away their messages. I think probably the right fix for this is to change these return types, either to `Result<(), crate::error::Error>`, or I don't know, maybe by adding an associated `type Error: Into<ProgramError>`. I tried the first option. It ends up being a bit of a slog that I never quite managed to finish, and it's a breaking change that requires changing a lot of tests (there are some test ix handlers that rely on auto-`into`-ing `ProgramError`s in functions returning `Result<()>`, but that breaks if Anchor traits start using `crate::error::Error`).

So, I thought it was worth starting a PR with something way hackier, based on the original idea I tried: macro generate a mapping from Custom(u32) --> Anchor's ErrorCode enum (we don't need to do this for your own custom `#[error]` enums because you can just use a good return type for your ix handlers, and then the dyn trait stuff handles the rest). This feels so gross but it does seem to work?
