### PR TITLE
Enable Test Validator Account Cloning

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -459,15 +459,34 @@ fn deser_programs(
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Test {
-    pub genesis: Vec<GenesisEntry>,
+    pub genesis: GenesisState,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GenesisEntry {
+pub struct GenesisState {
+    // Programs to embed into genesis
+    pub programs: Vec<GenesisProgram>,
+    // Accounts to embed into genesis
+    pub accounts: Option<Vec<GenesisAccount>>,
+    // Network url to clone genesis accounts from
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GenesisProgram {
     // Base58 pubkey string.
     pub address: String,
     // Filepath to the compiled program to embed into the genesis.
     pub program: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GenesisAccount {
+    // Base58 pubkey string of the mainnet account to clone
+    // embedding into gensis
+    pub address: String,
+    // Name of the account, used only for documentation
+    pub name: String,
 }
 
 #[derive(Debug, Clone)]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1531,11 +1531,20 @@ fn genesis_flags(cfg: &WithPath<Config>) -> Result<Vec<String>> {
         }
     }
     if let Some(test) = cfg.test.as_ref() {
-        for entry in &test.genesis {
+        for entry in &test.genesis.programs {
             flags.push("--bpf-program".to_string());
             flags.push(entry.address.clone());
             flags.push(entry.program.clone());
         }
+        if test.genesis.accounts.is_some() && test.genesis.url.is_some() {
+            flags.push("--url".to_string());
+            flags.push(test.genesis.url.clone().unwrap());
+            for entry in &test.genesis.clone().accounts.unwrap() {
+                flags.push("--clone".to_string());
+                flags.push(entry.address.clone());
+            }
+        }
+        
     }
     Ok(flags)
 }
@@ -1572,7 +1581,7 @@ fn stream_logs(config: &WithPath<Config>) -> Result<Vec<std::process::Child>> {
         handles.push(child);
     }
     if let Some(test) = config.test.as_ref() {
-        for entry in &test.genesis {
+        for entry in &test.genesis.programs {
             let log_file = File::create(format!("{}/{}.log", program_logs_dir, entry.address))?;
             let stdio = std::process::Stdio::from(log_file);
             let child = std::process::Command::new("solana")


### PR DESCRIPTION
# Overview

Solves https://github.com/project-serum/anchor/issues/533 by allowing one to specify a list of account addresses to clone from a specified cluster. As is this is a breaking change to the configuration file format. However the change allows for future additions to tweaking test validator behaviour without introducing breaking changes. 

Example of an anchor config file using the changes included in this PR:

```TOML
[test.genesis]
url = "https://api.mainnet-beta.solana.com"
[[test.genesis.programs]]
address = "9KEPoZmtHUrBbhWN1v1KWLMkkvwY6WLtAVUCPRtRjP4z"
program = "./deps/raydium/stake_program_v5.so"
[[test.genesis.accounts]]
address = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
name = "USDC-TOKEN-MINT"
```