### PR TITLE
Rename fields in token program instructions wrapper

### DIFF
--- a/spl/src/token.rs
+++ b/spl/src/token.rs
@@ -64,7 +64,7 @@ pub fn burn<'a, 'b, 'c, 'info>(
 ) -> ProgramResult {
     let ix = spl_token::instruction::burn(
         &spl_token::ID,
-        ctx.accounts.to.key,
+        ctx.accounts.account.key,
         ctx.accounts.mint.key,
         ctx.accounts.authority.key,
         &[],
@@ -73,7 +73,7 @@ pub fn burn<'a, 'b, 'c, 'info>(
     solana_program::program::invoke_signed(
         &ix,
         &[
-            ctx.accounts.to.clone(),
+            ctx.accounts.account.clone(),
             ctx.accounts.mint.clone(),
             ctx.accounts.authority.clone(),
             ctx.program.clone(),
@@ -88,7 +88,7 @@ pub fn approve<'a, 'b, 'c, 'info>(
 ) -> ProgramResult {
     let ix = spl_token::instruction::approve(
         &spl_token::ID,
-        ctx.accounts.to.key,
+        ctx.accounts.source.key,
         ctx.accounts.delegate.key,
         ctx.accounts.authority.key,
         &[],
@@ -97,7 +97,7 @@ pub fn approve<'a, 'b, 'c, 'info>(
     solana_program::program::invoke_signed(
         &ix,
         &[
-            ctx.accounts.to.clone(),
+            ctx.accounts.source.clone(),
             ctx.accounts.delegate.clone(),
             ctx.accounts.authority.clone(),
             ctx.program.clone(),
@@ -261,13 +261,13 @@ pub struct MintTo<'info> {
 #[derive(Accounts)]
 pub struct Burn<'info> {
     pub mint: AccountInfo<'info>,
-    pub to: AccountInfo<'info>,
+    pub account: AccountInfo<'info>,
     pub authority: AccountInfo<'info>,
 }
 
 #[derive(Accounts)]
 pub struct Approve<'info> {
-    pub to: AccountInfo<'info>,
+    pub source: AccountInfo<'info>,
     pub delegate: AccountInfo<'info>,
     pub authority: AccountInfo<'info>,
 }


### PR DESCRIPTION
just noticed these instructions names did not match the names in the real spl token program ix