### PR TITLE
Re-added "Wallet" and "workspace" back to TS declaration files

### DIFF
--- a/ts/src/index.ts
+++ b/ts/src/index.ts
@@ -22,3 +22,9 @@ if (!isBrowser) {
   exports.workspace = require("./workspace.js").default;
   exports.Wallet = require("./nodewallet.js").default;
 }
+
+import type NodeWallet from "./nodewallet.js"
+export declare class Wallet extends NodeWallet {}
+
+import type Workspace from "./workspace.js"
+export declare const workspace: typeof Workspace


### PR DESCRIPTION
This is a proposed change to make it easy to import `anchor.Wallet` and `anchor.workspace`.

See the issue https://github.com/project-serum/anchor/issues/1153

After this change:
- The declaration file once again contains `Wallet` and `workspace` after the build. Therefore e.g. `import { Wallet } from 'project-serum/anchor'` works again.
- The web build does not contain the code of the workspace.js or nodewallet.js as only the types are re-exported.