### PR TITLE
Make common public

### DIFF
--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -34,7 +34,7 @@ use std::io::Write;
 mod account_meta;
 pub mod accounts;
 mod bpf_upgradeable_state;
-mod common;
+pub mod common;
 pub mod context;
 mod ctor;
 mod error;


### PR DESCRIPTION
It would be useful to be able to access the `close` account function from the common module. 

Alternatively `close` could be added to `prelude`.