### PR TITLE
cli: replace program.rpc with program.methods in mocha test template

### DIFF
--- a/cli/src/template.rs
+++ b/cli/src/template.rs
@@ -201,7 +201,7 @@ describe("{}", () => {{
   it("Is initialized!", async () => {{
     // Add your test here.
     const program = anchor.workspace.{};
-    const tx = await program.rpc.initialize();
+    const tx = await program.methods.initialize().rpc();
     console.log("Your transaction signature", tx);
   }});
 }});
@@ -261,7 +261,7 @@ describe("{}", () => {{
 
   it("Is initialized!", async () => {{
     // Add your test here.
-    const tx = await program.rpc.initialize({{}});
+    const tx = await program.methods.initialize({{}}).rpc();
     console.log("Your transaction signature", tx);
   }});
 }});


### PR DESCRIPTION
Signed-off-by: Nikhil B N <nikhilbn365@gmail.com>

Fixes #1463 

`program.rpc` will be deprecated eventually