### PR TITLE
add avm use --yes <version> for non-interactive use

### DIFF
--- a/avm/src/lib.rs
+++ b/avm/src/lib.rs
@@ -46,18 +46,23 @@ pub fn version_binary_path(version: &Version) -> PathBuf {
 }
 
 /// Update the current version to a new version
-pub fn use_version(version: &Version) -> Result<()> {
+pub fn use_version(version: &Version, force_yes: bool) -> Result<()> {
     let installed_versions = read_installed_versions();
     // Make sure the requested version is installed
     if !installed_versions.contains(version) {
-        let input: String = Input::new()
-            .with_prompt(format!(
-                "anchor-cli {} is not installed, would you like to install it? (y/n)",
-                version
-            ))
-            .default("n".into())
-            .interact_text()?;
-        if matches!(input.as_str(), "y" | "yy" | "Y" | "yes" | "Yes") {
+        let mut matches_yes = true;
+        if !force_yes {
+            let input: String = Input::new()
+                .with_prompt(format!(
+                    "anchor-cli {} is not installed, would you like to install it? (y/n)",
+                    version
+                ))
+                .default("n".into())
+                .interact_text()?;
+            matches_yes = matches!(input.as_str(), "y" | "yy" | "Y" | "yes" | "Yes")
+        }
+
+        if matches_yes {
             install_version(version)?;
         } else {
             println!(

--- a/avm/src/main.rs
+++ b/avm/src/main.rs
@@ -15,8 +15,13 @@ pub struct Cli {
 pub enum Commands {
     #[clap(about = "Use a specific version of Anchor")]
     Use {
+        // Version to install
         #[clap(parse(try_from_str = parse_version))]
         version: Version,
+
+        // Don't prompt y/n (useful for non-interactive scripts)
+        #[clap(short, long)]
+        yes: bool,
     },
     #[clap(about = "Install a version of Anchor")]
     Install {
@@ -42,7 +47,7 @@ fn parse_version(version: &str) -> Result<Version, Error> {
 }
 pub fn entry(opts: Cli) -> Result<()> {
     match opts.command {
-        Commands::Use { version } => avm::use_version(&version),
+        Commands::Use { version, yes } => avm::use_version(&version, yes),
         Commands::Install { version } => avm::install_version(&version),
         Commands::Uninstall { version } => avm::uninstall_version(&version),
         Commands::List {} => avm::list_versions(),


### PR DESCRIPTION
using `avm use latest` in a Dockerfile, causes it to sit forever waiting for an input that will never come (same for any other build system use)

so this PR adds `avm use --yes latest`, which bypasses the "are you sure you want to do what you just asked"? interactive prompt


essentially the same idea as `apt-get install -y libudev-dev`