### PR TITLE
ts: parse events from confirmed transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ incremented for features.
 
 * lang: Add new `AccountSysvarMismatch` error code and test cases for sysvars ([#1535](https://github.com/project-serum/anchor/pull/1535)).
 * spl: Add support for revoke instruction ([#1493](https://github.com/project-serum/anchor/pull/1493)).
+* ts: Add `getEventsFromTransaction` function to the `events` namespace to parse previous transaction events ([#1584](https://github.com/project-serum/anchor/pull/1584)).
 
 ### Fixes
 


### PR DESCRIPTION
the `events` namespace now has a `getEventsFromTransaction` function to parse the program logs from a confirmed transaction and return an array of found events.