### PR TITLE
fix: Move opts to env static call

### DIFF
--- a/tests/errors/tests/errors.ts
+++ b/tests/errors/tests/errors.ts
@@ -64,11 +64,12 @@ const withLogTest = async (callback, expectedLogs) => {
 
 describe("errors", () => {
   // Configure the client to use the local cluster.
-  const localProvider = anchor.Provider.local();
-  localProvider.opts.skipPreflight = true;
   // processed failed tx do not result in AnchorErrors in the client
   // because we cannot get logs for them (only through overkill `onLogs`)
-  localProvider.opts.commitment = "confirmed";
+  const localProvider = anchor.Provider.local(undefined, {
+    skipPreflight: true,
+    commitment: "confirmed",
+  });
   anchor.setProvider(localProvider);
 
   const program = anchor.workspace.Errors as Program<Errors>;

--- a/ts/src/provider.ts
+++ b/ts/src/provider.ts
@@ -64,7 +64,7 @@ export default class Provider {
    *
    * (This api is for Node only.)
    */
-  static env(): Provider {
+  static env(opts?: ConfirmOptions): Provider {
     if (isBrowser) {
       throw new Error(`Provider env is not available on browser.`);
     }
@@ -74,7 +74,7 @@ export default class Provider {
     if (url === undefined) {
       throw new Error("ANCHOR_PROVIDER_URL is not defined");
     }
-    const options = Provider.defaultOptions();
+    const options = opts ?? Provider.defaultOptions();
     const connection = new Connection(url, options.commitment);
     const NodeWallet = require("./nodewallet.js").default;
     const wallet = NodeWallet.local();


### PR DESCRIPTION
Found trying to write a test expecting an `AnchorError`, but could only get a weird 
`Translating error: ConfirmError: Raw transaction 2JeqjZLw8RoYVDJha1tVbioyKQPHsGVXhXWUNs6we1y5jCKMhmGsDRn1BYgaDfBXryqdPet6zXb72zHb8UUazkDr failed ({"err":{"InstructionError":[0,{"Custom":6004}]}})`

https://discord.com/channels/889577356681945098/899315988087054397/957551186846818315

I think to avoid any headache we should provide opts only through the `Provider` static helpers or `Provider` ctor, then not even expose provider.opts, or as readonly later on since it can create odd state.

`readonly opts` opts on provider is readonly but tests and people might just poke through and mutate it.
the answer https://stackoverflow.com/a/68058145 readonly is useless.