### PR TITLE
style: use slice::split_at to separate sighash and ix_data

### DIFF
--- a/lang/syn/src/codegen/program/dispatch.rs
+++ b/lang/syn/src/codegen/program/dispatch.rs
@@ -142,13 +142,7 @@ pub fn generate(program: &Program) -> proc_macro2::TokenStream {
         ) -> anchor_lang::Result<()> {
             // Split the instruction data into the first 8 byte method
             // identifier (sighash) and the serialized instruction data.
-            let mut ix_data: &[u8] = data;
-            let sighash: [u8; 8] = {
-                let mut sighash: [u8; 8] = [0; 8];
-                sighash.copy_from_slice(&ix_data[..8]);
-                ix_data = &ix_data[8..];
-                sighash
-            };
+            let (sighash, mut ix_data) = data.split_at(8);
 
             // If the method identifier is the IDL tag, then execute an IDL
             // instruction, injected into all Anchor programs.


### PR DESCRIPTION
`copy_from_slice` copies 8 bytes, whereas `split_at` merely creates new references

same safety guarantees as: len(data) >= 8

Ref: https://doc.rust-lang.org/stable/std/primitive.slice.html#method.split_at