### PR TITLE
added discriminant offset when decoding program

### DIFF
--- a/ts/src/utils/registry.ts
+++ b/ts/src/utils/registry.ts
@@ -85,7 +85,7 @@ const UPGRADEABLE_LOADER_STATE_LAYOUT = borsh.rustEnum(
 );
 
 export function decodeUpgradeableLoaderState(data: Buffer): any {
-  return UPGRADEABLE_LOADER_STATE_LAYOUT.decode(data);
+  return UPGRADEABLE_LOADER_STATE_LAYOUT.decode(data, 8);
 }
 
 export type ProgramData = {


### PR DESCRIPTION
Currently, when I use the `utils.registry.fetchData` function, the following error occurs:
```
TypeError: Cannot read properties of null (reading 'property')
      at Union.decode (node_modules/buffer-layout/lib/Layout.js:1692:16)
      at decodeUpgradeableLoaderState (node_modules/@project-serum/anchor/src/utils/registry.ts:88:42)
      at Object.fetchData (node_modules/@project-serum/anchor/src/utils/registry.ts:54:23)
```

It seems the issue is caused by the `UnionLayout` not finding the proper layout for the disciminant. Adding `8` to the second argument of `UnionLayout.decode`, to denote the length of the discriminant that anchor programs use, fixes the issue