### PR TITLE
Pass in ts-mocha `--exit` flag to default config

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -528,7 +528,7 @@ fn init(cfg_override: &ConfigOverride, name: String, javascript: bool, no_git: b
         if javascript {
             "yarn run mocha -t 1000000 tests/"
         } else {
-            "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+            "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts --exit"
         }
         .to_owned(),
     );


### PR DESCRIPTION
`anchor test` sometimes hangs after completing a test suite.